### PR TITLE
Fix documentation enableJobs example property logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,9 +241,7 @@ adapted build method of the `CustomJobBuilder` class looks like this:
 Job build(Class<? extends Job> jobClass, @DelegatesTo(Job.class) Closure closure) {
     def job = super.build(jobClass, closure)
     job.with {
-        if (!DslConfig.get('enableJobs')) {
-            disabled()
-        }
+        disabled(!DslConfig.get('enableJobs'))
     }
     return job
 }


### PR DESCRIPTION
The logic is flawed in case of the job is already disabled and the value of `enableJobs` is true. In that case the job will not be update to be enabled.